### PR TITLE
Fixed  PHP Fatal error:  Class 'Tar' not found

### DIFF
--- a/VerboseTarLib.class.php
+++ b/VerboseTarLib.class.php
@@ -9,6 +9,8 @@
  * @author Bouchon <tarlib@bouchon.org> (Maxg)
  * @license GPL 2
  */
+use \TarLib as Tar;
+
 class VerboseTar {
 
     const COMPRESS_AUTO = 0;


### PR DESCRIPTION
When I was upgrading from Adora Belle to Ponder Stibbons got error

PHP Fatal error:  Class 'Tar' not found in /data/rodev/www/wiki/lib/plugins/upgrade/admin.php on line 327

This quick hack solved the problem
