### PR TITLE
Adjust version number when we compare versions

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -236,7 +236,7 @@ class admin_plugin_upgrade extends DokuWiki_Admin_Plugin {
 
         // get the available version
         $http       = new DokuHTTPClient();
-        $tgzversion = $http->get($this->tgzversion);
+        $tgzversion = trim($http->get($this->tgzversion));
         if(!$tgzversion) {
             $this->_warn($this->getLang('vs_tgzno').' '.hsc($http->error));
             $ok = false;
@@ -250,7 +250,8 @@ class admin_plugin_upgrade extends DokuWiki_Admin_Plugin {
         }
 
         // get the current version
-        $version = getVersion();
+        $versiondata = getVersionData();
+        $version = trim($versiondata['date']);
         $versionnum = $this->dateFromVersion($version);
         self::_say($this->getLang('vs_local'), $version);
 


### PR DESCRIPTION
Plugin alway shows an available upgrade. This is cause when we compare full version strings, they differ:
- $tgzversion value is: 2020-07-29 "Hogfather"
- $version value is: Release 2020-07-29 "Hogfather"

This fix use the getVersionData() function to ignore the "Release" string added using getVersion() function.

Also, $tgzversion value may contain spaces at the end. So we add a trim() for both variables.

Fix #201
The bug was introduced in commit 27c6a3e.