### PR TITLE
Update .travis.yml to remove old PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: php
 php:
   - "7.3"
   - "7.2"
-  - "7.1"
-  - "7.0"
-  - "5.6"
 env:
   - DOKUWIKI=master
   - DOKUWIKI=stable


### PR DESCRIPTION
Removed testing platform for PHP 7.1, 7.0, 5.6

This will avoid failing tests that are no more relevant.

As per commit splitbrain/dokuwiki@34c8d5b, PHP < 7.2 is no more supported